### PR TITLE
refactor: Update artifact upload path in python-publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -56,7 +56,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.repo-name.outputs.repository-name }}-${{ steps.get_tag_name.outputs.version }}-${{ matrix.target.triple }}
-        path: artifact/${{ steps.repo-name.outputs.repository-name }}-${{ steps.get_tag_name.outputs.version }}-${{ matrix.target.triple }}.zip
+        path: artifact/*.zip
 
   upload-artifact:
     needs: deploy

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,18 @@
+# Import built-in modules
+import importlib
+import pkgutil
+
+# Import local modules
+import ftwd_datatalk
+
+
+def test_imports():
+    """Test import modules."""
+    prefix = "{}.".format(ftwd_datatalk.__name__)
+    iter_packages = pkgutil.walk_packages(
+        ftwd_datatalk.__path__,
+        prefix,
+    )
+    for _, name, _ in iter_packages:
+        module_name = name if name.startswith(prefix) else prefix + name
+        importlib.import_module(module_name)


### PR DESCRIPTION
Updated the artifact upload path in the python-publish workflow to use a wildcard for zipped artifacts.